### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/KnowTheCode/UpDevTools",
   "license": "GPL-2.0+",
   "require": {
-    "php": "^5.6 || ^7",
+    "php": "^5.6 || ^7 || ^8.0",
     "kint-php/kint": "^1",
     "filp/whoops": "^2"
   },


### PR DESCRIPTION
I have the latest version of PHP installed (8.0.1) and after running the composter install command, I received the following error in my PhpStorm terminal window:

=====================================================================================
 Problem 1
    - Root composer.json requires php ^5.6 || ^7 but your php version (8.0.1) does not satisfy that requirement.
  Problem 2
    - filp/whoops is locked to version 2.3.1 and an update of this package was not requested.
    - filp/whoops 2.3.1 requires php ^5.5.9 || ^7.0 -> your php version (8.0.1) does not satisfy that requirement.
=====================================================================================

I simply made the following changes on line 8 of the composer.json file to circumvent the error:

"php": "^5.6 || ^7 || ^8.0",

I simply appended the "|| ^8.0" and reran the composer install command and it ran with no errors.