### PR TITLE
Update kintParser.class.php

### DIFF
--- a/vendor/kint-php/kint/inc/kintParser.class.php
+++ b/vendor/kint-php/kint/inc/kintParser.class.php
@@ -460,9 +460,9 @@ abstract class kintParser extends kintVariableData
 			 * These prepended values have null bytes on either side.
 			 * http://www.php.net/manual/en/language.types.array.php#language.types.array.casting
 			 */
-			if ( $key{0} === "\x00" ) {
+			if ( $key[0] === "\x00" ) {
 
-				$access = $key{1} === "*" ? "protected" : "private";
+				$access = $key[1] === "*" ? "protected" : "private";
 
 				// Remove the access level from the variable name
 				$key = substr( $key, strrpos( $key, "\x00" ) + 1 );


### PR DESCRIPTION
I was receiving the following PHP errors after activating the plugin in my local dev environment because I have PHP version 8.0.1 installed:

========================================================

Fatal error: Array and string offset access syntax with curly braces is no longer supported in "Site/app/public/wp-content/plugins/UpDevTools/vendor/kint-php/kint/inc/kintParser.class.php"

========================================================

I simply updated lines 463 and 465 to use brackets instead of curly braces.